### PR TITLE
Revert "use install instead of symlink"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,11 +17,11 @@ jobs:
       - name: Install dnscrypt-proxy
         run: brew install dnscrypt-proxy
 
-      - name: Install sandbox file to /Users/runner
-        run: sudo install -o root -g wheel dnscrypt-proxy.sb ~
+      - name: Copy sandbox file to /Users/runner
+        run: cp dnscrypt-proxy.sb /Users/runner
 
-      - name: Install chDaemon plist to /Library/LaunchDaemons
-        run: sudo install -o root -g wheel goonnowgit.dnscrypt-proxy.plist /Library/LaunchDaemons
+      - name: Copy LauchDaemon plist to /Library/LaunchDaemons
+        run: sudo cp goonnowgit.dnscrypt-proxy.plist /Library/LaunchDaemons
 
       - name: Just use cloudflare to make the start up process quick
         run: sed -i -e "s/^# server_names.*$/server_names = ['cloudflare']/" /usr/local/etc/dnscrypt-proxy.toml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Get initial log
         run: sleep 5 && cat /usr/local/etc/dnscrypt-proxy.log
-
+        
       - name: Give it a moment...
         run: while [[ -z $(grep "dnscrypt-proxy is ready" /usr/local/etc/dnscrypt-proxy.log) ]]; do sleep 1; done
 
@@ -46,3 +46,4 @@ jobs:
 
       - name: Do a DNS lookup
         run: dig @127.0.0.1 www.google.com
+

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ cd macos-dnscrypt-proxy-sandbox
 ```
 #### Setup Links
 ```
-sudo install -o root -g wheel goonnowgit.dnscrypt-proxy.plist /Library/LaunchDaemons
-sudo install -o root -g wheel dnscrypt-proxy.sb ~
+sudo ln -s "${PWD}"/goonnowgit.dnscrypt-proxy.plist /Library/LaunchDaemons
+ln -s "${PWD}"/dnscrypt-proxy.sb "${HOME}"
 ```
 #### Start the sandboxed dnscrypt-proxy via launchctl
 ```
@@ -44,7 +44,7 @@ sudo dtruss /usr/local/sbin/dnscrypt-proxy -config /usr/local/etc/dnscrypt-proxy
 ```
 networksetup -setdnsservers 'Wi-Fi' 127.0.0.1
 ```
-or just
+or just 
 ```
 dig @127.0.0.1 <some domain>
 ```
@@ -58,7 +58,7 @@ perl -lne 'print "$1" if /syscall::(\w+):return/ || /(^[\w\d_]{4,}?)\(/' dnscryp
 
 ### Start the Console.app
 * Press start (play button) at the top of the window
-* Set the filter to *syscall-unix*
+* Set the filter to *syscall-unix* 
 * Start the sandboxed dnscrypt-proxy
 ```
 sudo sandbox-exec -f "${HOME}"/dnscrypt-proxy.sb /usr/local/opt/dnscrypt-proxy/sbin/dnscrypt-proxy --config /usr/local/etc/dnscrypt-proxy.toml
@@ -76,7 +76,7 @@ kernel Sandbox: sandbox-exec(<pid>) deny(1) syscall-unix <syscall #>
 
 * **Disclaimer**: This is still a work in progress and is ultimately for fun...
 
-* Also, as Apple states in their sandbox files:
+* Also, as Apple states in their sandbox files: 
 ```
 WARNING: The sandbox rules in this file currently constitute
 Apple System Private Interface and are subject to change at any time and

--- a/dnscrypt-proxy.sb
+++ b/dnscrypt-proxy.sb
@@ -1,5 +1,3 @@
-# vim: set ft=lisp
-
 (version 1)
 ;(trace "dnscrypt.sb")
 (import "bsd.sb")


### PR DESCRIPTION
Reverts GoOnNowGit/macos-dnscrypt-proxy-sandbox#4